### PR TITLE
Use ruby-2.1.3 in Wercker CI

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -3,7 +3,7 @@ box: wercker/rvm
 build:
     steps:
         - rvm-use:
-            version: 2.1.0
+            version: 2.1.3
 
         - script:
             name: gem install bundler


### PR DESCRIPTION
Because ruby-2.1.0 is not prepared in Wercker RVM.
